### PR TITLE
add androidConfig parameter to config in MsalGuard

### DIFF
--- a/lib/src/msal_guard_widget.dart
+++ b/lib/src/msal_guard_widget.dart
@@ -106,6 +106,8 @@ class _MsalGuardState extends State<MsalGuard> {
         clientId: clientId,
         androidRedirectUri: this.androidRedirectUri,
         iosRedirectUri: this.iosRedirectUri,
+        androidConfig: MSALAndroidConfig(
+            authorities: [Authority(authorityUrl: Uri.parse(authority))]),
         authority: Uri.parse(authority),
       ),
       defaultScopes: scopes,


### PR DESCRIPTION
I was getting a strange error when clicking on the Login button in the `msal_guard` example project while running it on an Android device:

```
D/MsalFlutter(31198): Msal exception caugth unknown_error
D/MsalFlutter(31198): com.microsoft.identity.client.exception.MsalClientException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
D/MsalFlutter(31198): 	at com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter.msalExceptionFromBaseException(MsalExceptionAdapter.java:51)
D/MsalFlutter(31198): 	at com.microsoft.identity.client.PublicClientApplication$18.onError(PublicClientApplication.java:1944)
D/MsalFlutter(31198): 	at com.microsoft.identity.client.PublicClientApplication$18.onError(PublicClientApplication.java:1935)
D/MsalFlutter(31198): 	at com.microsoft.identity.client.PublicClientApplication$14$1.run(PublicClientApplication.java:1567)
D/MsalFlutter(31198): 	at android.os.Handler.handleCallback(Handler.java:938)
D/MsalFlutter(31198): 	at android.os.Handler.dispatchMessage(Handler.java:99)
D/MsalFlutter(31198): 	at android.os.Looper.loop(Looper.java:233)
D/MsalFlutter(31198): 	at android.app.ActivityThread.main(ActivityThread.java:8030)
D/MsalFlutter(31198): 	at java.lang.reflect.Method.invoke(Native Method)
D/MsalFlutter(31198): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
D/MsalFlutter(31198): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
D/MsalFlutter(31198): Caused by: com.microsoft.identity.common.java.exception.ClientException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
D/MsalFlutter(31198): 	at com.microsoft.identity.common.java.controllers.ExceptionAdapter.baseExceptionFromException(ExceptionAdapter.java:335)
D/MsalFlutter(31198): 	at com.microsoft.identity.client.PublicClientApplication$14.run(PublicClientApplication.java:1561)
D/MsalFlutter(31198): 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:462)
D/MsalFlutter(31198): 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
D/MsalFlutter(31198): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
D/MsalFlutter(31198): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
D/MsalFlutter(31198): 	at java.lang.Thread.run(Thread.java:923)
D/MsalFlutter(31198): Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
D/MsalFlutter(31198): 	at com.microsoft.identity.client.internal.CommandParametersAdapter.createInteractiveTokenCommandParameters(CommandParametersAdapter.java:148)
D/MsalFlutter(31198): 	at com.microsoft.identity.client.PublicClientApplication$14.run(PublicClientApplication.java:1541)
D/MsalFlutter(31198): 	... 5 more
E/flutter (31198): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Instance of 'MsalException'
E/flutter (31198): #0      MSALPublicClientApplication.acquireToken (package:msal_flutter/src/msal_public_client_application.dart:69:7)
E/flutter (31198): <asynchronous suspension>
E/flutter (31198): #1      AuthenticationService.login (package:msal_guard/src/authentication_service.dart:145:7)
E/flutter (31198): <asynchronous suspension>
```

No clue what causes it, all I know is that the example project in `msal_flutter` repository works well for me, and the example project in `msal_guard` doesn't. So I compared the code, found this single difference, tried it, and now the example in `msal_guard` works too.

I've read the announcement, I'm not waiting for you guys to resolve this PR, I'm going to use this from my own repository. But if you encounter a similar problem, looking at this PR might help you solve it.